### PR TITLE
Fast payouts

### DIFF
--- a/libraries/chain/base_evaluator.cpp
+++ b/libraries/chain/base_evaluator.cpp
@@ -91,7 +91,6 @@ void account_create_evaluator::do_apply( const account_create_operation& o )
       acc.last_owner_update = fc::time_point_sec::min();
       acc.created = props.time;
       acc.last_vote_time = props.time;
-      acc.mined = false;
 
       acc.recovery_account = o.creator;
 
@@ -348,18 +347,14 @@ void withdraw_vesting_evaluator::do_apply( const withdraw_vesting_operation& o )
     FC_ASSERT( account.vesting_shares >= asset( 0, VESTS_SYMBOL ) );
     FC_ASSERT( account.vesting_shares - account.delegated_vesting_shares >= o.vesting_shares, "Account does not have sufficient Steem Power for withdraw." );
 
-    if( !account.mined )  {
-      const auto& props = db().get_dynamic_global_properties();
-      const witness_schedule_object& wso = db().get_witness_schedule_object();
+    const auto& props = db().get_dynamic_global_properties();
+    const witness_schedule_object& wso = db().get_witness_schedule_object();
 
-      asset min_vests = wso.median_props.account_creation_fee * props.get_vesting_share_price();
-      min_vests.amount.value *= 10;
+    asset min_vests = wso.median_props.account_creation_fee * props.get_vesting_share_price();
+    min_vests.amount.value *= 10;
 
-      FC_ASSERT( account.vesting_shares > min_vests,
-                 "Account registered by another account requires 10x account creation fee worth of Vestings before it can power down" );
-    }
-
-
+    FC_ASSERT( account.vesting_shares > min_vests,
+               "Account registered by another account requires 10x account creation fee worth of Vestings before it can power down" );
 
     if( o.vesting_shares.amount <= 0 ) {
        if( o.vesting_shares.amount == 0 ) // SOFT FORK, remove after HF 4

--- a/libraries/chain/base_evaluator.cpp
+++ b/libraries/chain/base_evaluator.cpp
@@ -163,7 +163,6 @@ void account_create_with_delegation_evaluator::do_apply( const account_create_wi
       acc.last_owner_update = fc::time_point_sec::min();
       acc.created = props.time;
       acc.last_vote_time = props.time;
-      acc.mined = false;
       acc.received_vesting_shares = o.delegation;
 
       #ifndef IS_LOW_MEM

--- a/libraries/chain/include/muse/chain/account_object.hpp
+++ b/libraries/chain/include/muse/chain/account_object.hpp
@@ -31,16 +31,13 @@ namespace muse { namespace chain {
          time_point_sec  last_owner_update;
 
          time_point_sec  created;
-         bool            mined = true;
          bool            owner_challenged = false;
          bool            active_challenged = false;
          time_point_sec  last_owner_proved = time_point_sec::min();
          time_point_sec  last_active_proved = time_point_sec::min();
          string          recovery_account = "";
          time_point_sec  last_account_recovery;
-         uint32_t        comment_count = 0;
          uint32_t        lifetime_vote_count = 0;
-         uint32_t        post_count = 0;
 
          uint64_t        score=0;
          
@@ -69,9 +66,6 @@ namespace muse { namespace chain {
          fc::time_point_sec mbd_seconds_last_update; ///< the last time the mbd_seconds was updated
          fc::time_point_sec mbd_last_interest_payment; ///< used to pay interest at most once per month
          ///@}
-
-         share_type      curation_rewards = 0;
-         share_type      posting_rewards = 0;
 
          asset           vesting_shares = asset( 0, VESTS_SYMBOL ); ///< total vesting shares held by this account, controls its voting power
          asset           delegated_vesting_shares = asset( 0, VESTS_SYMBOL );
@@ -104,17 +98,12 @@ namespace muse { namespace chain {
 
          uint64_t        average_market_bandwidth  = 0;
          time_point_sec  last_market_bandwidth_update;
-         time_point_sec  last_post;
-         time_point_sec  last_root_post = fc::time_point_sec::min();
-         uint32_t        post_bandwidth = 0;
 
          /**
           *  Used to track activity rewards, updated on every post and comment
           */
          ///@{
          time_point_sec  last_active;
-         fc::uint128_t   activity_shares;
-         time_point_sec  last_activity_payout;
          ///@}
 
 
@@ -254,12 +243,10 @@ namespace muse { namespace chain {
 
    struct by_name;
    struct by_proxy;
-   struct by_last_post;
    struct by_next_vesting_withdrawal;
    struct by_muse_balance;
    struct by_smp_balance;
    struct by_smd_balance;
-   struct by_post_count;
    struct by_vote_count;
    struct by_last_owner_update;
 
@@ -285,13 +272,6 @@ namespace muse { namespace chain {
                member<object, object_id_type, &object::id >
             > /// composite key by_next_vesting_withdrawal
          >,
-         ordered_unique< tag< by_last_post >,
-            composite_key< account_object,
-               member<account_object, time_point_sec, &account_object::last_post >,
-               member<object, object_id_type, &object::id >
-            >,
-            composite_key_compare< std::greater< time_point_sec >, std::less< object_id_type > >
-         >,
          ordered_unique< tag< by_muse_balance >,
             composite_key< account_object,
                member<account_object, asset, &account_object::balance >,
@@ -312,13 +292,6 @@ namespace muse { namespace chain {
                member<object, object_id_type, &object::id >
             >,
             composite_key_compare< std::greater< asset >, std::less< object_id_type > >
-         >,
-         ordered_unique< tag< by_post_count >,
-            composite_key< account_object,
-               member<account_object, uint32_t, &account_object::post_count >,
-               member<object, object_id_type, &object::id >
-            >,
-            composite_key_compare< std::greater< uint32_t >, std::less< object_id_type > >
          >,
          ordered_unique< tag< by_vote_count >,
             composite_key< account_object,
@@ -492,20 +465,18 @@ namespace muse { namespace chain {
 }}
 FC_REFLECT_DERIVED( muse::chain::account_object, (graphene::db::object),
                     (name)(owner)(active)(basic)(memo_key)(json_metadata)(proxy)(last_owner_update)
-                    (created)(mined)(total_listening_time)
+                    (created)(total_listening_time)
                     (owner_challenged)(active_challenged)(last_owner_proved)(last_active_proved)(recovery_account)(last_account_recovery)
-                    (comment_count)(lifetime_vote_count)(post_count)(voting_power)(last_vote_time)
+                    (lifetime_vote_count)(voting_power)(last_vote_time)
                     (balance)
                     (mbd_balance)(mbd_seconds)(mbd_seconds_last_update)(mbd_last_interest_payment)
                     (vesting_shares)(delegated_vesting_shares)(received_vesting_shares)
                     (vesting_withdraw_rate)(next_vesting_withdrawal)(withdrawn)(to_withdraw)(withdraw_routes)
-                    (curation_rewards)
-                    (posting_rewards)(score)
+                    (score)
                     (proxied_vsf_votes)(witnesses_voted_for)(streaming_platforms_voted_for)
                     (average_bandwidth)(lifetime_bandwidth)(last_bandwidth_update)
                     (average_market_bandwidth)(last_market_bandwidth_update)
-                    (last_post)(last_root_post)(post_bandwidth)
-                    (last_active)(activity_shares)(last_activity_payout)
+                    (last_active)
                     (friends)(second_level)(waiting)
                   )
 FC_REFLECT_DERIVED( muse::chain::vesting_delegation_object, (graphene::db::object),

--- a/libraries/chain/include/muse/chain/database.hpp
+++ b/libraries/chain/include/muse/chain/database.hpp
@@ -326,8 +326,6 @@ namespace muse { namespace chain {
          asset get_content_reward()const;
          asset get_curation_reward()const;
 
-      uint16_t get_curation_rewards_percent() const;
-
 
          //////////////////// db_getter.cpp ////////////////////
 

--- a/libraries/chain/include/muse/chain/global_property_object.hpp
+++ b/libraries/chain/include/muse/chain/global_property_object.hpp
@@ -110,6 +110,26 @@ namespace muse { namespace chain {
          uint64_t current_reserve_ratio = 1;
 
          uint32_t delegation_return_period = MUSE_DELEGATION_RETURN_PERIOD;
+
+         /** The number of users who have at least one streaming report in the
+          *  last 24 hours
+          */
+         uint32_t active_users = 0;
+
+         /** The number of users who have at least 1 hour worth of streaming
+          *  reports in the last 24 hours
+          */
+         uint32_t full_time_users = 0;
+
+         /** Total listening time within the past 24 hours, in seconds.
+          */
+         uint32_t total_listening_time = 0;
+
+         /** Full user time within the past 24 hours, in seconds. Means sum of
+          *  the total listening time of all users, capped at 1 hour for each
+          *  user.
+          */
+         uint32_t full_users_time = 0;
    };
 }}
 
@@ -137,5 +157,9 @@ FC_REFLECT_DERIVED( muse::chain::dynamic_global_property_object, (graphene::db::
                     (max_virtual_bandwidth)
                     (current_reserve_ratio)
                     (delegation_return_period)
+                    (active_users)
+                    (full_time_users)
+                    (total_listening_time)
+                    (full_users_time)
                   )
 

--- a/libraries/chain/include/muse/chain/protocol/base_operations.hpp
+++ b/libraries/chain/include/muse/chain/protocol/base_operations.hpp
@@ -628,9 +628,9 @@ namespace muse { namespace chain {
     * during an attack. These 30 days match the 30 days that an
     * owner authority is valid for recovery purposes.
     *
-    * On account creation the recovery account is set either to the creator of
-    * the account (The account that pays the creation fee and is a signer on the transaction)
-    * or to the empty string if the account was mined. An account with no recovery
+    * On account creation the recovery account is set to the creator of the
+    * account (i. e. the account that pays the creation fee and is a signer on
+    * the transaction). An account with no recovery
     * has the top voted witness as a recovery account, at the time the recover
     * request is created. Note: This does mean the effective recovery account
     * of an account with no listed recovery account can change at any time as

--- a/tests/tests/muse_tests.cpp
+++ b/tests/tests/muse_tests.cpp
@@ -661,20 +661,6 @@ BOOST_AUTO_TEST_CASE( simple_test )
       BOOST_CHECK_EQUAL( 100000, veronica_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, vici_id(db).vesting_shares.amount.value );
 
-      BOOST_CHECK_EQUAL( 0, alice_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, penny_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, priscilla_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, cora_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, coreen_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, veronica_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, vici_id(db).curation_rewards.value );
-
       BOOST_CHECK_EQUAL( 7200, colette_id(db).total_listening_time );
       BOOST_CHECK_EQUAL( 3600, cora_id(db).total_listening_time );
       BOOST_CHECK_EQUAL( 1800, coreen_id(db).total_listening_time );
@@ -751,20 +737,6 @@ BOOST_AUTO_TEST_CASE( simple_test )
       BOOST_CHECK_EQUAL( 100000, coreen_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, veronica_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, vici_id(db).vesting_shares.amount.value );
-
-      BOOST_CHECK_EQUAL( 0, alice_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, penny_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, priscilla_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, cora_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, coreen_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, veronica_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, vici_id(db).curation_rewards.value );
 
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
       BOOST_CHECK_EQUAL( 0, cora_id(db).total_listening_time );
@@ -1052,16 +1024,6 @@ BOOST_AUTO_TEST_CASE( multi_test )
       BOOST_CHECK_EQUAL( 100000, veronica_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, vici_id(db).vesting_shares.amount.value );
 
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, penny_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, veronica_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, vici_id(db).curation_rewards.value );
-
       BOOST_CHECK_EQUAL( 3600, colette_id(db).total_listening_time );
 
       generate_blocks( db.head_block_time() + 86400 - MUSE_BLOCK_INTERVAL );
@@ -1117,16 +1079,6 @@ BOOST_AUTO_TEST_CASE( multi_test )
       BOOST_CHECK_EQUAL( 100000, colette_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, veronica_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, vici_id(db).vesting_shares.amount.value );
-
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, penny_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, veronica_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, vici_id(db).curation_rewards.value );
 
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
       }
@@ -1298,13 +1250,6 @@ BOOST_AUTO_TEST_CASE( simple_authority_test )
       BOOST_CHECK_EQUAL( 100000, muriel_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, colette_id(db).vesting_shares.amount.value );
 
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
-
       BOOST_CHECK_EQUAL( 86400, colette_id(db).total_listening_time );
 
       asset daily_content_reward = db.get_content_reward();
@@ -1347,13 +1292,6 @@ BOOST_AUTO_TEST_CASE( simple_authority_test )
       BOOST_CHECK_EQUAL( 100000, martha_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, muriel_id(db).vesting_shares.amount.value );
       BOOST_CHECK_EQUAL( 100000, colette_id(db).vesting_shares.amount.value );
-
-      BOOST_CHECK_EQUAL( 0, suzy_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, uhura_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, paula_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, martha_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, muriel_id(db).curation_rewards.value );
-      BOOST_CHECK_EQUAL( 0, colette_id(db).curation_rewards.value );
 
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
 

--- a/tests/tests/muse_tests.cpp
+++ b/tests/tests/muse_tests.cpp
@@ -454,6 +454,12 @@ BOOST_AUTO_TEST_CASE( simple_test )
       BOOST_CHECK_EQUAL( song1.id, reports[0].content );
       BOOST_CHECK_EQUAL( db.head_block_time().sec_since_epoch(), reports[0].created.sec_since_epoch() );
       BOOST_CHECK_EQUAL( 7200, reports[0].play_time );
+
+      const auto& dgpo = db.get_dynamic_global_properties();
+      BOOST_CHECK_EQUAL( 3, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 2, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 9000, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 12600, dgpo.total_listening_time );
       }
       const auto& played_at = db.head_block_time();
 
@@ -741,6 +747,11 @@ BOOST_AUTO_TEST_CASE( simple_test )
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
       BOOST_CHECK_EQUAL( 0, cora_id(db).total_listening_time );
       BOOST_CHECK_EQUAL( 0, coreen_id(db).total_listening_time );
+
+      BOOST_CHECK_EQUAL( 0, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 0, dgpo.total_listening_time );
       }
 
       validate_database();
@@ -911,6 +922,12 @@ BOOST_AUTO_TEST_CASE( multi_test )
       tx.operations.clear();
       tx.operations.push_back( spro );
       db.push_transaction( tx, database::skip_transaction_signatures  );
+
+      const auto& dgpo = db.get_dynamic_global_properties();
+      BOOST_CHECK_EQUAL( 1, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 1, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 3600, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 3600, dgpo.total_listening_time );
       }
 
       // --------- Content update ------------
@@ -1081,6 +1098,11 @@ BOOST_AUTO_TEST_CASE( multi_test )
       BOOST_CHECK_EQUAL( 100000, vici_id(db).vesting_shares.amount.value );
 
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
+
+      BOOST_CHECK_EQUAL( 0, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 0, dgpo.total_listening_time );
       }
 
       validate_database();
@@ -1164,12 +1186,23 @@ BOOST_AUTO_TEST_CASE( simple_authority_test )
       tx.sign( suzy_private_key, db.get_chain_id() );
       db.push_transaction( tx, 0 );
 
+      const auto& dgpo = db.get_dynamic_global_properties();
+      BOOST_CHECK_EQUAL( 1, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 100, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 100, dgpo.total_listening_time );
+
       spro.play_time = 86300;
       tx.operations.clear();
       tx.operations.push_back( spro );
       tx.signatures.clear();
       tx.sign( suzy_private_key, db.get_chain_id() );
       db.push_transaction( tx, 0 );
+
+      BOOST_CHECK_EQUAL( 1, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 1, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 3600, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 86400, dgpo.total_listening_time );
 
       spro.play_time = 1;
       tx.operations.clear();
@@ -1294,6 +1327,11 @@ BOOST_AUTO_TEST_CASE( simple_authority_test )
       BOOST_CHECK_EQUAL( 100000, colette_id(db).vesting_shares.amount.value );
 
       BOOST_CHECK_EQUAL( 0, colette_id(db).total_listening_time );
+
+      BOOST_CHECK_EQUAL( 0, dgpo.active_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_time_users );
+      BOOST_CHECK_EQUAL( 0, dgpo.full_users_time );
+      BOOST_CHECK_EQUAL( 0, dgpo.total_listening_time );
 
       validate_database();
    }


### PR DESCRIPTION
Fixes #46 - improves replay time from currently ~38 minutes to ~9 minutes (!)

Provides some metrics on active users and listening time as a side effect.