### PR TITLE
RC->testnet

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -83,8 +83,6 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       uint64_t get_account_scoring( string account );
       uint64_t get_content_scoring( string content );
       // Market
-      order_book get_order_book( uint32_t limit )const;
-      order_book get_order_book_for_asset( asset_id_type asset_id, uint32_t limit )const;
       vector< liquidity_balance > get_liquidity_queue( string start_account, uint32_t limit )const;
 
       //Assets
@@ -944,7 +942,7 @@ vector<content_object> database_api_impl::list_content_by_uploader( const string
 
 order_book database_api::get_order_book( uint32_t limit )const
 {
-   return my->get_order_book( limit );
+   return get_order_book_for_assets(MUSE_SYMBOL, MBD_SYMBOL, limit);
 }
 
 vector<extended_limit_order> database_api::get_open_orders( string owner )const {
@@ -963,92 +961,47 @@ vector<extended_limit_order> database_api::get_open_orders( string owner )const 
    return result;
 }
 
-order_book database_api_impl::get_order_book( uint32_t limit )const
-{ //TODO_MUSE - change to support more symbols
-   FC_ASSERT( limit <= 1000 );
-   order_book result;
-
-   auto max_sell = price::max( MBD_SYMBOL, MUSE_SYMBOL );
-   auto max_buy = price::max( MUSE_SYMBOL, MBD_SYMBOL );
-
-   const auto& limit_price_idx = _db.get_index_type<limit_order_index>().indices().get<by_price>();
-   auto sell_itr = limit_price_idx.lower_bound(max_sell);
-   auto buy_itr  = limit_price_idx.lower_bound(max_buy);
-   auto end = limit_price_idx.end();
-
-   while(  sell_itr != end && sell_itr->sell_price.base.asset_id == MBD_SYMBOL && result.bids.size() < limit )
-   {
-      auto itr = sell_itr;
-      order cur;
-      cur.order_price = itr->sell_price;
-      cur.real_price  = (cur.order_price).to_real();
-      cur.quote = itr->for_sale;
-      cur.base = ( asset( itr->for_sale, MBD_SYMBOL ) * cur.order_price ).amount;
-      cur.created = itr->created;
-      result.bids.push_back( cur );
-      ++sell_itr;
-   }
-   while(  buy_itr != end && buy_itr->sell_price.base.asset_id == MUSE_SYMBOL && result.asks.size() < limit )
-   {
-      auto itr = buy_itr;
-      order cur;
-      cur.order_price = itr->sell_price;
-      cur.real_price  = (~cur.order_price).to_real();
-      cur.base   = itr->for_sale;
-      cur.quote     = ( asset( itr->for_sale, MUSE_SYMBOL ) * cur.order_price ).amount;
-      cur.created = itr->created;
-      result.asks.push_back( cur );
-      ++buy_itr;
-   }
-
-   return result;
-}
-
 order_book database_api::get_order_book_for_asset( asset_id_type asset_id, uint32_t limit )const
 {
-   return my->get_order_book_for_asset( asset_id, limit ); 
+   return get_order_book_for_assets(asset_id, MBD_SYMBOL, limit);
 }
-order_book database_api_impl::get_order_book_for_asset( asset_id_type asset_id, uint32_t limit )const
+order_book database_api::get_order_book_for_assets( asset_id_type base_id, asset_id_type quote_id, uint32_t limit )const
 { 
    FC_ASSERT( limit <= 1000 );
    order_book result;
-   result.base = MUSE_SYMBOL;
-   result.quote = asset_id;
 
-   const auto& limit_price_idx = _db.get_index_type<limit_order_index>().indices().get<by_price>();
-   auto sell_itr = limit_price_idx.lower_bound( price::max( MUSE_SYMBOL, asset_id ) );
-   auto sell_end  = limit_price_idx.upper_bound(  price::min( MUSE_SYMBOL, asset_id ) );
-   auto buy_itr = limit_price_idx.lower_bound( price::max( asset_id, MUSE_SYMBOL ) );
-   auto buy_end  = limit_price_idx.upper_bound(  price::min( asset_id, MUSE_SYMBOL ) );
-   
-   uint32_t count = 0;
-   while(  sell_itr != sell_end && count < limit )
+   result.base = base_id(my->_db).symbol_string;
+   result.quote = quote_id(my->_db).symbol_string;
+
+   const auto& limit_price_idx = my->_db.get_index_type<limit_order_index>().indices().get<by_price>();
+   auto sell_itr = limit_price_idx.lower_bound( price::max( base_id, quote_id ) );
+   auto sell_end  = limit_price_idx.upper_bound(  price::min( base_id, quote_id ) );
+   auto buy_itr = limit_price_idx.lower_bound( price::max( quote_id, base_id ) );
+   auto buy_end  = limit_price_idx.upper_bound(  price::min( quote_id, base_id ) );
+
+   while( sell_itr != sell_end && sell_itr->sell_price.base.asset_id == base_id && result.asks.size() < limit )
    {
-      auto itr = sell_itr;
-      order cur;
-      cur.order_price = itr->sell_price;
-      cur.real_price  = (cur.order_price).to_real();
-      cur.quote = itr->for_sale;
-      cur.base = ( asset( itr->for_sale, asset_id ) * cur.order_price ).amount;
-      cur.created = itr->created;
-      result.bids.push_back( cur );
+      result.asks.emplace_back();
+      order& cur = result.asks.back();
+      cur.order_price = ~sell_itr->sell_price;
+      cur.real_price  = cur.order_price.to_real();
+      cur.base = sell_itr->for_sale;
+      cur.quote = ( asset( sell_itr->for_sale, sell_itr->sell_price.base.asset_id ) * cur.order_price ).amount;
+      cur.created = sell_itr->created;
       ++sell_itr;
-      ++count;
    }
-   count = 0;
-   while(  buy_itr != buy_end && count < limit )
+   while( buy_itr != buy_end && buy_itr->sell_price.base.asset_id == quote_id && result.bids.size() < limit )
    {
-      auto itr = buy_itr;
-      order cur;
-      cur.order_price = itr->sell_price;
-      cur.real_price  = (~cur.order_price).to_real();
-      cur.base  = itr->for_sale;
-      cur.quote  = ( asset( itr->for_sale, MUSE_SYMBOL ) * cur.order_price ).amount;
-      cur.created = itr->created;
-      result.asks.push_back( cur );
+      result.bids.emplace_back();
+      order& cur = result.bids.back();
+      cur.order_price = buy_itr->sell_price;
+      cur.real_price  = cur.order_price.to_real();
+      cur.base = ( asset( buy_itr->for_sale, buy_itr->sell_price.base.asset_id ) * cur.order_price ).amount;
+      cur.quote = buy_itr->for_sale;
+      cur.created = buy_itr->created;
       ++buy_itr;
-      ++count;
    }
+
    return result;
 }
 

--- a/libraries/app/include/muse/app/database_api.hpp
+++ b/libraries/app/include/muse/app/database_api.hpp
@@ -189,7 +189,15 @@ class database_api
        * @ingroup db_api
        */
       asset_object get_asset( asset_id_type asset_id )const;
-      
+
+      /****************
+       * Get all holders of the given asset
+       * @param asset_id ID of the asset to look for
+       * @return a mapping of account ids and asset balances
+       * @ingroup db_api
+       */
+      map<account_id_type, share_type> get_asset_holders( asset_id_type asset_id )const;
+
       /****************
        * Get User Issued Asset balances for a particular account
        * @param account Account to look for
@@ -609,6 +617,7 @@ FC_API(muse::app::database_api,
    (lookup_uias)
    (get_uia_details)
    (get_asset)
+   (get_asset_holders)
    (get_uia_balances)
    //score
    (get_account_scoring)

--- a/libraries/app/include/muse/app/database_api.hpp
+++ b/libraries/app/include/muse/app/database_api.hpp
@@ -431,18 +431,26 @@ class database_api
       ////////////
 
       /**
-       * @breif Gets the current order book for ASSET:SBD market
+       * @breif Gets the current order book for MUSE:MBD market
        * @param limit Maximum number of orders for each side of the spread to return -- Must not exceed 1000
        * @return Order book
        */
       order_book get_order_book( uint32_t limit = 1000 )const;
       /**
-       * Gets the current order book for the given asset market
+       * Gets the current order book for the given asset:MBD market
        * @param asset_id Asset ID to look for
        * @param limit Maximum number of orders for each side of the spread to return -- Must not exceed 1000
        * @return Order book
        */
       order_book get_order_book_for_asset( asset_id_type asset_id,  uint32_t limit = 1000 )const;
+      /**
+       * Gets the current order book for the given market pair
+       * @param base_id first Asset ID to look for
+       * @param quote_id second asset ID to look for
+       * @param limit Maximum number of orders for each side of the spread to return -- Must not exceed 1000
+       * @return Order book
+       */
+      order_book get_order_book_for_assets( asset_id_type base_id, asset_id_type quote_id, uint32_t limit = 1000 )const;
       /**
        * Get open orders by the given account
        * @param owner Account opening the orders
@@ -587,6 +595,7 @@ FC_API(muse::app::database_api,
    // Market
    (get_order_book)
    (get_order_book_for_asset)
+   (get_order_book_for_assets)
    (get_open_orders)
    (get_liquidity_queue)
 

--- a/libraries/chain/base_evaluator.cpp
+++ b/libraries/chain/base_evaluator.cpp
@@ -597,6 +597,9 @@ void convert_evaluator::do_apply( const convert_operation& o )
 
 void limit_order_create_evaluator::do_apply( const limit_order_create_operation& o )
 {
+   if( !db().has_hardfork(MUSE_HARDFORK_0_6) )
+      FC_ASSERT( o.amount_to_sell.asset_id == MBD_SYMBOL || o.min_to_receive.asset_id == MBD_SYMBOL );
+
    FC_ASSERT( o.expiration > db().head_block_time() );
 
    const auto& owner = db().get_account( o.owner );
@@ -622,6 +625,9 @@ void limit_order_create_evaluator::do_apply( const limit_order_create_operation&
 
 void limit_order_create2_evaluator::do_apply( const limit_order_create2_operation& o )
 {
+   if( !db().has_hardfork(MUSE_HARDFORK_0_6) )
+      FC_ASSERT( o.exchange_rate.base.asset_id == MBD_SYMBOL || o.exchange_rate.quote.asset_id == MBD_SYMBOL );
+
    FC_ASSERT( o.expiration > db().head_block_time() );
 
    const auto& owner = db().get_account( o.owner );

--- a/libraries/chain/protocol/base_operations.cpp
+++ b/libraries/chain/protocol/base_operations.cpp
@@ -164,7 +164,6 @@ namespace muse { namespace chain {
    void limit_order_create_operation::validate()const
    {
       FC_ASSERT( is_valid_account_name( owner ) );
-      FC_ASSERT ( is_asset_type( amount_to_sell, MBD_SYMBOL ) ||  is_asset_type( min_to_receive, MBD_SYMBOL ) );
       FC_ASSERT ( !is_asset_type( min_to_receive, VESTS_SYMBOL ) && !is_asset_type( amount_to_sell, VESTS_SYMBOL ) );
       (amount_to_sell / min_to_receive).validate();
    }
@@ -174,7 +173,6 @@ namespace muse { namespace chain {
       FC_ASSERT( amount_to_sell.asset_id == exchange_rate.base.asset_id );
       exchange_rate.validate();
 
-      FC_ASSERT ( is_asset_type( exchange_rate.base, MBD_SYMBOL ) ||  is_asset_type( exchange_rate.quote, MBD_SYMBOL ) );
       FC_ASSERT ( !is_asset_type( exchange_rate.base, VESTS_SYMBOL ) && !is_asset_type( exchange_rate.quote, VESTS_SYMBOL ) );
 
       FC_ASSERT( (amount_to_sell * exchange_rate).amount > 0 ); // must not round to 0

--- a/tests/tests/api_tests.cpp
+++ b/tests/tests/api_tests.cpp
@@ -735,4 +735,75 @@ BOOST_AUTO_TEST_CASE( list_content )
    BOOST_CHECK_EQUAL( 1, songs[0].id.instance() );
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE( asset_holders )
+{ try {
+   muse::app::database_api db_api( db );
+
+   ACTORS( (alice)(bob)(charlie)(federation) );
+
+   fund( "alice", 50000 );
+   vest( "alice", 50000 );
+   fund( "bob", 10000 );
+
+   BOOST_CHECK(db_api.get_asset_holders(MBD_SYMBOL).empty());
+   auto holders = db_api.get_asset_holders(MUSE_SYMBOL);
+   BOOST_CHECK(!holders.empty());
+   auto itr = holders.find(bob_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_EQUAL(10000, itr->second.value);
+
+   holders = db_api.get_asset_holders(VESTS_SYMBOL);
+   BOOST_CHECK_LT(4u, holders.size());
+   itr = holders.find(alice_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_LT(50000, itr->second.value);
+   itr = holders.find(bob_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_LT(0, itr->second.value);
+   itr = holders.find(charlie_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_LT(0, itr->second.value);
+   itr = holders.find(federation_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_LT(0, itr->second.value);
+
+   trx.clear();
+   trx.set_expiration( db.head_block_time() + MUSE_MAX_TIME_UNTIL_EXPIRATION );
+
+   {
+      asset_create_operation aco;
+      aco.issuer = "federation";
+      aco.symbol = "BTS";
+      aco.precision = 5;
+      aco.common_options.description = "IOU for BitShares core token";
+      trx.operations.emplace_back(std::move(aco));
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+   }
+
+   const asset_object& bts = db.get_asset("BTS");
+   BOOST_CHECK_EQUAL(0, bts.current_supply.value);
+
+   BOOST_CHECK(db_api.get_asset_holders(bts.id).empty());
+
+   {
+      asset_issue_operation aio;
+      aio.issuer = "federation";
+      aio.asset_to_issue = bts.amount(5000);
+      aio.issue_to_account = "charlie";
+      trx.operations.emplace_back(std::move(aio));
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+   }
+
+   holders = db_api.get_asset_holders(bts.id);
+   BOOST_CHECK_EQUAL(1u, holders.size());
+   itr = holders.find(charlie_id);
+   BOOST_REQUIRE(itr != holders.end());
+   BOOST_CHECK_EQUAL(5000, itr->second.value);
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/asset_tests.cpp
+++ b/tests/tests/asset_tests.cpp
@@ -191,6 +191,136 @@ BOOST_AUTO_TEST_CASE(trade_asset_test)
     BOOST_CHECK_EQUAL(100000, amount.amount.value);
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE(trade_assets_test)
+{ try {
+    ACTORS( (alice)(bob)(federation));
+    fund("alice");
+    vest("alice", 50000);
+    fund("bob", 5000000);
+    vest("bob", 50000);
+
+    trx.clear();
+    trx.set_expiration( db.head_block_time() + MUSE_MAX_TIME_UNTIL_EXPIRATION );
+
+    {
+        asset_create_operation aco;
+        aco.issuer = "federation";
+        aco.symbol = "BTS";
+        aco.precision = 5;
+        aco.common_options.description = "IOU for BitShares core token";
+        trx.operations.emplace_back(aco);
+        aco.symbol = "BTC";
+        aco.precision = 8;
+        aco.common_options.description = "IOU for Bitcoin";
+        trx.operations.emplace_back(std::move(aco));
+        sign(trx, federation_private_key);
+        PUSH_TX(db, trx);
+        trx.clear();
+    }
+
+    const asset_object& bts = db.get_asset("BTS");
+    const asset_object& btc = db.get_asset("BTC");
+
+    {
+        asset_issue_operation aio;
+        aio.issuer = "federation";
+        aio.asset_to_issue = bts.amount(5000000);
+        aio.issue_to_account = "bob";
+        trx.operations.emplace_back(aio);
+        aio.asset_to_issue = btc.amount(500000);
+        aio.issue_to_account = "alice";
+        trx.operations.emplace_back(std::move(aio));
+        sign(trx, federation_private_key);
+        PUSH_TX(db, trx);
+        trx.clear();
+    }
+
+    {
+        limit_order_create_operation loc;
+        loc.owner = "alice";
+        loc.amount_to_sell = btc.amount(10000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(30000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = btc.amount(11000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(34000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = btc.amount(12000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(38000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = btc.amount(20000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(3000000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = btc.amount(21000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(3250000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = btc.amount(22000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(3500000000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(1000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(10);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(1100);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(12);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(1200);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(14);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        sign(trx, alice_private_key);
+        PUSH_TX(db, trx);
+        trx.clear();
+
+        loc.owner = "bob";
+        loc.amount_to_sell = bts.amount(100000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(200000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = bts.amount(110000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(230000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = bts.amount(120000);
+        loc.min_to_receive = MBD_SYMBOL(db).amount(260000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = bts.amount(100000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(30000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = bts.amount(110000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(34000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = bts.amount(120000);
+        loc.min_to_receive = MUSE_SYMBOL(db).amount(38000);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(300000);
+        loc.min_to_receive = btc.amount(20);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(325000);
+        loc.min_to_receive = btc.amount(21);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        loc.amount_to_sell = MUSE_SYMBOL(db).amount(350000);
+        loc.min_to_receive = btc.amount(22);
+        trx.operations.emplace_back(loc);
+        loc.orderid++;
+        sign(trx, bob_private_key);
+        PUSH_TX(db, trx);
+        trx.clear();
+    }
+} FC_LOG_AND_RETHROW() }
+
 BOOST_FIXTURE_TEST_CASE( hardfork_test, database_fixture )
 { try {
 

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -2384,15 +2384,6 @@ BOOST_FIXTURE_TEST_CASE( convert_forward, database_fixture )
    BOOST_CHECK_EQUAL( fed_asset_id(db).mbd_balance.amount.value, ASSET( "0.001 2.28.2" ).amount.value );
 } FC_LOG_AND_RETHROW() }
 
-BOOST_AUTO_TEST_CASE( limit_order_create_validate )
-{
-   try
-   {
-      BOOST_TEST_MESSAGE( "Testing: limit_order_create_validate" );
-   }
-   FC_LOG_AND_RETHROW()
-}
-
 BOOST_AUTO_TEST_CASE( limit_order_create_authorities )
 {
    try
@@ -2422,12 +2413,6 @@ BOOST_AUTO_TEST_CASE( limit_order_create_authorities )
       tx.sign( alice_private_key, db.get_chain_id() );
       MUSE_REQUIRE_THROW( db.push_transaction( tx, database::skip_transaction_dupe_check ), tx_duplicate_sig );
 
-/*      BOOST_TEST_MESSAGE( "--- Test failure with additional incorrect signature" );
-      tx.signatures.clear();
-      tx.sign( alice_private_key, db.get_chain_id() );
-      tx.sign( bob_private_key, db.get_chain_id() );
-      MUSE_REQUIRE_THROW( db.push_transaction( tx, database::skip_transaction_dupe_check ), tx_irrelevant_sig );
-*/
       BOOST_TEST_MESSAGE( "--- Test failure with incorrect signature" );
       tx.signatures.clear();
       tx.sign( alice_post_key, db.get_chain_id() );
@@ -2755,12 +2740,6 @@ BOOST_AUTO_TEST_CASE( limit_order_create2_authorities )
       tx.sign( alice_private_key, db.get_chain_id() );
       MUSE_REQUIRE_THROW( db.push_transaction( tx, database::skip_transaction_dupe_check ), tx_duplicate_sig );
 
-/*      BOOST_TEST_MESSAGE( "--- Test failure with additional incorrect signature" );
-      tx.signatures.clear();
-      tx.sign( alice_private_key, db.get_chain_id() );
-      tx.sign( bob_private_key, db.get_chain_id() );
-      MUSE_REQUIRE_THROW( db.push_transaction( tx, database::skip_transaction_dupe_check ), tx_irrelevant_sig );
-*/
       BOOST_TEST_MESSAGE( "--- Test failure with incorrect signature" );
       tx.signatures.clear();
       tx.sign( alice_post_key, db.get_chain_id() );


### PR DESCRIPTION
* new `get_asset_holders` API call to return all holders of an asset, with balance amounts
* no longer require MBD to be part of a trade, i. e. allow arbitrary market pairs
* add `get_order_book_for_assets(base, quote, limit)` API call to retrieve the order book in a specific market